### PR TITLE
fixing speciesControlledVocabulary

### DIFF
--- a/schema/NIAIDDataset.json
+++ b/schema/NIAIDDataset.json
@@ -215,7 +215,7 @@
             "type": "string",
             "vocabulary": {
               "ontology": ["ncbitaxon"],
-              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567", "http://purl.obolibrary.org/obo/NCBITaxon_10239", "http://purl.obolibrary.org/obo/NCBITaxon_131567l"]
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567", "http://purl.obolibrary.org/obo/NCBITaxon_10239"]
             },
             "strict": false
           },


### PR DESCRIPTION
I'm pretty sure the removed value `http://purl.obolibrary.org/obo/NCBITaxon_131567l` is a typo variant of the first value `http://purl.obolibrary.org/obo/NCBITaxon_131567`, but hope others will confirm/verify