### PR TITLE
add working NIAID ComputationalTool schema. 

### DIFF
--- a/schema/NIAIDComputationalTool.json
+++ b/schema/NIAIDComputationalTool.json
@@ -1,0 +1,576 @@
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "niaid": "http://discovery.biothings.io/view/niaid/"
+  },
+  "@graph": [
+    {
+      "@id": "niaid:NiaidComputationalTool",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A schema describing a minimal ComputationalTool for the National Institute of Allergy and Infectious Disease (NIAID). A ComputationalTool is a software used for the collection, processing, distribution, analysis, visualization, interpretation, etc. of data. Additional schema.org and/or custom properties could be added.",
+      "rdfs:label": "NiaidComputationalTool",
+      "rdfs:subClassOf": {
+        "@id": "schema:SoftwareApplication"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Descriptive name of the computational tool",
+            "type": "string"
+          },
+          "description": {
+            "description": "Longer description of what is contained in the computational tool",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "A short unique identifier for the computational tool (ideally less than 15 characters)",
+            "type": "string"
+          },
+          "creator": {
+            "description": "Name of the author or organization that created the computational tool.  Note: schema.org/creator and schema.org/organization have additional fields that can provide more information about the author/organization, if desired.",
+            "anyOf": [{
+                "$ref": "#/definitions/person"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/person"
+                }
+              },
+              {
+                "$ref": "#/definitions/organization"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/organization"
+                }
+              }
+            ]
+          },
+          "url": {
+            "description": "software/code location.",
+            "type": "string",
+            "format": "uri"
+          },
+          "dateModified": {
+            "type": "string",
+            "format": "date"
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string",
+            "format": "uri"
+          },
+          "citation": {
+            "description": "Journal article or other publication associated with the computational tool (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/article"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/article"
+                }
+              }
+            ]
+          },
+          "applicationCategory": {
+            "description": "Type of software application, e.g. 'Game, Multimedia'. Please use terms from the 'Tool type' table in the biotools documentation.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            ]
+          },
+          "applicationSubCategory": {
+            "description": "Subcategory of the application, e.g. 'Arcade Game'. Use an EDAM:Topic to describe the category of application",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/edamTopic"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/edamTopic"
+                }
+              }
+            ]
+          },
+          "codeRepository": {
+            "description": "Link to the source code repository of the tool.",
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            ]
+          },
+          "programmingLanguage": {
+            "description": "The main programming language(s) used to build or execute the tool. Please use terms from the ‘Programming language’ table in the Bio.Tools documentation",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "softwareVersion": {
+            "description": "Version(s) of the tool, which this information is valid for. Can also be a comma-delimited list and include hyphen-separated ranges of versions.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "featureList": {
+            "description": "Features or modules provided by this application (and possibly required by other applications). Functionality provided by the tool. This is similar to measurementTechnique in Dataset.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/edamOperation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/edamOperation"
+                }
+              },
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            ]
+          },
+          "species": {
+            "description": "Species(es) from which the computation tool is based",
+            "oneOf": [{
+                "$ref": "#/definitions/speciesControlledVocabulary"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/speciesControlledVocabulary"
+                }
+              }
+            ]
+          },
+          "infectiousAgent": {
+            "description": "Infectious agent(s) / pathogen(s) which are the focus of the computational tool (e.g. SARS-CoV-2)",
+            "oneOf": [{
+                "$ref": "#/definitions/pathogenControlledVocabulary"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/pathogenControlledVocabulary"
+                }
+              }
+            ]
+          },
+          "infectiousDisease": {
+            "description": "Infectious disease(s) or condition(s) which are the focus of the computational tool (e.g. COVID-19, pneumonia, etc.)",
+            "oneOf": [{
+                "$ref": "#/definitions/diseaseControlledVocabulary"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/diseaseControlledVocabulary"
+                }
+              }
+            ]
+          },
+          "funding": {
+            "description": "Funding that supports (sponsors) the collection of this computational tool through some kind of financial contribution",
+            "oneOf": [{
+                "$ref": "#/definitions/monetaryGrant"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/monetaryGrant"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "identifier",
+          "creator",
+          "url",
+          "funding"
+        ],
+        "definitions": {
+          "edamTopic": {
+            "@type": "DefinedTerm",
+            "type": "object",
+            "strict": false,
+            "vocabulary": {
+              "ontology": [
+                "edamTopic"
+              ],
+              "children_of": [
+                "http://edamontology.org/topic_0003"
+              ],
+              "property": {
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "edamOperation": {
+            "@type": "DefinedTerm",
+            "type": "object",
+            "strict": false,
+            "vocabulary": {
+              "ontology": [
+                "edamOperation"
+              ],
+              "children_of": [
+                "http://edamontology.org/operation_0004"
+              ],
+              "property": {
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "article": {
+            "description": "A scholarly article in which the computational tool is cited.",
+            "@type": "ScholarlyArticle",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": [
+              "url"
+            ]
+          },
+          "person": {
+            "description": "Reusable person definition",
+            "@type": "Person",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "organization": {
+            "description": "Reusable organization definition",
+            "@type": "Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "pathogenControlledVocabulary": {
+            "description": "collection of vocabulary terms defined in ontologies",
+            "@type": "CreativeWork",
+            "type": "string",
+            "vocabulary": {
+              "ontology": ["ncbitaxon"],
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239", "http://purl.obolibrary.org/obo/NCBITaxon_2"]
+            },
+            "strict": false
+          },
+          "speciesControlledVocabulary": {
+            "description": "collection of vocabulary terms defined in ontologies",
+            "@type": "CreativeWork",
+            "type": "string",
+            "vocabulary": {
+              "ontology": ["ncbitaxon"],
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567", "http://purl.obolibrary.org/obo/NCBITaxon_10239", "http://purl.obolibrary.org/obo/NCBITaxon_131567l"]
+            },
+            "strict": false
+          },
+          "diseaseControlledVocabulary": {
+            "description": "collection of vocabulary terms defined in ontologies",
+            "@type": "CreativeWork",
+            "type": "string",
+            "vocabulary": {
+              "ontology": ["mondo"],
+              "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]
+            },
+            "strict": false
+          },
+          "monetaryGrant": {
+            "type": "object",
+            "@type": "MonetaryGrant",
+            "description": "Funding that supports (sponsors) the collection of this computational tool through some kind of financial contribution",
+            "properties": {
+              "funder": {
+                "description": "An organization associated with a creator or funder of a computational tool",
+                "oneOf": [{
+                    "$ref": "#/definitions/funder"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/funder"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "type": "string",
+                "description": "description about the funding award / grant"
+              },
+              "url": {
+                "type": "string",
+                "description": "award / grant URL"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the Dataset"
+              }
+            },
+            "required": [
+              "funder",
+              "identifier"
+            ]
+          },
+          "funder": {
+            "type": "object",
+            "@type": "Organization",
+            "description": "Information about a single funder",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "An organization associated with a creator or funder of a computational tool"
+              },
+              "parentOrganization": {
+                "type": "string",
+                "description": "name of the parent funding organization"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "@id": "niaid:codeRepository",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Link to the source code repository of the tool.",
+      "rdfs:label": "codeRepository",
+      "schema:domainIncludes": {
+        "@id": "niaid:NiaidComputationalTool"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "niaid:programmingLanguage",
+      "@type": "rdf:Property",
+      "rdfs:comment": "The main programming language(s) used to build or execute the tool. Please use terms from the ‘Programming language’ table in the Bio.Tools documentation",
+      "rdfs:label": "programmingLanguage",
+      "schema:domainIncludes": {
+        "@id": "niaid:NiaidComputationalTool"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:ComputerLanguage"
+        }
+      ]
+    },
+    {
+      "@id": "niaid:species",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Species(es) from which dataset has been collected",
+      "rdfs:label": "species",
+      "schema:domainIncludes": [{
+        "@id": "niaid:NiaidComputationalTool"
+      }],
+      "schema:rangeIncludes": [{
+        "@id": "schema:Text"
+      }],
+      "owl:cardinality": "many",
+      "marginality": "recommended"
+    },
+    {
+      "@id": "niaid:infectiousAgent",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Infectious agent(s) / pathogen(s) which are the focus of the dataset (e.g. SARS-CoV-2)",
+      "rdfs:label": "infectiousAgent",
+      "schema:domainIncludes": [{
+        "@id": "niaid:NiaidComputationalTool"
+      }],
+      "schema:rangeIncludes": [{
+        "@id": "schema:Text"
+      }],
+      "owl:cardinality": "many",
+      "marginality": "recommended"
+    },
+    {
+      "@id": "niaid:infectiousDisease",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Infectious disease(s) / condition(s) which are the focus of the dataset (e.g. COVID-19, coronavirus)",
+      "rdfs:label": "infectiousDisease",
+      "schema:domainIncludes": [{
+        "@id": "niaid:NiaidComputationalTool"
+      }],
+      "schema:rangeIncludes": [{
+        "@id": "schema:Text"
+      }],
+      "owl:cardinality": "many",
+      "marginality": "recommended"
+    },
+    {
+      "@id": "niaid:funding",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "funding",
+      "schema:domainIncludes": [{
+        "@id": "niaid:NiaidComputationalTool"
+      }],
+      "schema:rangeIncludes": [{
+        "@id": "niaid:NiaidMonetaryGrant"
+      }],
+      "schema:sameAs": {
+        "@id": "schema:funding"
+      },
+      "owl:cardinality": "many",
+      "marginality": "required"
+    },
+    {
+      "@id": "niaid:funder",
+      "@type": "rdf:Property",
+      "rdfs:comment": "An organization that supports (sponsors) something this dataset some kind of financial contribution.",
+      "rdfs:label": "funder",
+      "schema:domainIncludes": [{
+        "@id": "niaid:NiaidMonetaryGrant"
+      }],
+      "schema:rangeIncludes": {
+        "@id": "niaid:NiaidOrganization"
+      },
+      "schema:sameAs": {
+        "@id": "schema:funder"
+      },
+      "owl:cardinality": "one",
+      "marginality": "required"
+    },
+    {
+      "@id": "niaid:NiaidMonetaryGrant",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "NiaidMonetaryGrant",
+      "rdfs:subClassOf": {
+        "@id": "schema:MonetaryGrant"
+      },
+      "schema:isPartOf": {
+        "@id": "https://discovery.biothings.io/view/niaid/"
+      }
+    },
+    {
+      "@id": "niaid:NiaidOrganization",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "An organization associated with a creator or funder of a dataset",
+      "rdfs:label": "NiaidOrganization",
+      "rdfs:subClassOf": {
+        "@id": "schema:Organization"
+      },
+      "schema:isPartOf": {
+        "@id": "https://discovery.biothings.io/view/niaid/"
+      }
+    },
+    {
+      "@id": "niaid:NiaidScholarlyArticle",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A scholarly article in which the dataset is cited.",
+      "rdfs:label": "NiaidScholarlyArticle",
+      "rdfs:subClassOf": {
+        "@id": "schema:ScholarlyArticle"
+      },
+      "schema:isPartOf": {
+        "@id": "https://discovery.biothings.io/view/niaid/"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Note, that it was manually derived from the bioschemas:ComputationalTool, and should be subclassed as such, but there's a bug in the DDE preventing us from doing so. Thus it's currently subclassed to schema:SoftwareApplication